### PR TITLE
Only find OpenMP if target does not exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
-find_package(OpenMP REQUIRED)
+option(OPENMP "Enable OpenMP support" ON)
+if(NOT TARGET OpenMP::OpenMP_Fortran AND OPENMP)
+    find_package(OpenMP REQUIRED)
+endif()
 
 ###############################################################################
 ##                           DEFINE OPTIONS                                  ##

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,7 @@ add_library(ddx SHARED ${SRC})
 # Link against BLAS and LAPACK
 target_link_libraries(ddx PUBLIC ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 # OpenMP linkage
-target_link_libraries(ddx PUBLIC OpenMP::OpenMP_Fortran)
+target_link_libraries(ddx PUBLIC $<$<BOOL:${OPENMP}>:OpenMP::OpenMP_Fortran>)
 
 # Define ddx driver executable
 add_executable(ddx_driver "ddx_driver.f90")


### PR DESCRIPTION
Checks whether the `OpenMP::OpenMP_Fortran` target exists before looking for OpenMP. Also implements the `OPENMP` option documented in https://acom-computational-mathematics.github.io/ddX/dev/label_download_and_install.html.